### PR TITLE
[AVCe] Skip MFE check for backward compatiable

### DIFF
--- a/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
+++ b/_studio/mfx_lib/encode_hw/h264/src/mfx_h264_encode_hw.cpp
@@ -587,6 +587,9 @@ mfxStatus ImplementationAvc::Query(
                     if (IsRunTimeOnlyExtBuffer(in->ExtParam[i]->BufferId))
                         continue; // it's runtime only ext buffer. Nothing to check or correct, just move on.
 
+                    if (in->ExtParam[i]->BufferId == MFX_EXTBUFF_MULTI_FRAME_PARAM ||
+                        in->ExtParam[i]->BufferId == MFX_EXTBUFF_MULTI_FRAME_CONTROL)
+                        continue; // skip checking MFE buffers
 
                     MFX_CHECK(IsVideoParamExtBufferIdSupported(in->ExtParam[i]->BufferId),
                     MFX_ERR_UNSUPPORTED);

--- a/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_enc_common_hw.cpp
@@ -1712,6 +1712,7 @@ bool MfxHwH264Encode::IsRunTimeExtBufferIdSupported(MfxVideoParam const & video,
 #if defined (MFX_EXTBUFF_GPU_HANG_ENABLE)
         || id == MFX_EXTBUFF_GPU_HANG
 #endif
+        || id == MFX_EXTBUFF_MULTI_FRAME_CONTROL
 #if defined MFX_ENABLE_GPU_BASED_SYNC
         || id == MFX_EXTBUFF_GAME_STREAMING
 #endif
@@ -1781,6 +1782,8 @@ bool MfxHwH264Encode::IsVideoParamExtBufferIdSupported(mfxU32 id)
         || id == MFX_EXTBUFF_PRED_WEIGHT_TABLE
         || id == MFX_EXTBUFF_DIRTY_RECTANGLES
         || id == MFX_EXTBUFF_MOVING_RECTANGLES
+        || id == MFX_EXTBUFF_MULTI_FRAME_PARAM
+        || id == MFX_EXTBUFF_MULTI_FRAME_CONTROL
 #if defined(MFX_ENABLE_AVC_CUSTOM_QMATRIX)
         || id == MFX_EXTBUFF_AVC_SCALING_MATRIX
 #endif


### PR DESCRIPTION
MFE is removed. to make sure ffmpeg working, skip MFE check.