### PR TITLE
[HEVCe/AV1e] Fix parallel submission in task manager

### DIFF
--- a/_studio/mfx_lib/encode_hw/shared/ehw_task_manager.h
+++ b/_studio/mfx_lib/encode_hw/shared/ehw_task_manager.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Intel Corporation
+// Copyright (c) 2020-2021 Intel Corporation
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -101,6 +101,7 @@ namespace MfxEncodeHW
         mfxU16                  m_maxParallelSubmits = 0;
         mfxU16                  m_nTasksInExecution  = 0;
         mfxU16                  m_nRecodeTasks       = 0;
+        bool                    m_bPostponeQuery     = false;
         std::mutex              m_mtx, m_closeMtx;
         std::condition_variable m_cv;
 


### PR DESCRIPTION
Frame skip after recode with parallel submission leads to getting stuck
in Prepare stage for one task and losing parallel submission.

Issue: MDP-62789
Test: manual, hevce_swbrc_slw_interlaced-plugin_hevcehw