### PR TITLE
[mpeg2e] Call GetFrameHDL from FrameInterface (#1504)

### DIFF
--- a/_studio/mfx_lib/encode_hw/mpeg2/include/mfx_mpeg2_encode_full_hw.h
+++ b/_studio/mfx_lib/encode_hw/mpeg2/include/mfx_mpeg2_encode_full_hw.h
@@ -240,6 +240,7 @@ namespace MPEG2EncoderHW
                   (pFrames->m_pRefFrame[1])? pFrames->m_pRefFrame[1]->Data.MemId:0);
               MFX_CHECK_STS(sts);
 
+              m_pExecuteBuffers->m_pSurface = pFrames->m_pInputFrame;
               sts = m_pDdiEncoder->SetFrames(m_pExecuteBuffers);
               MFX_CHECK_STS(sts);
               sts = m_pDdiEncoder->Execute(m_pExecuteBuffers, pUserData,userDataLen);

--- a/_studio/mfx_lib/shared/include/mfx_mpeg2_encode_interface.h
+++ b/_studio/mfx_lib/shared/include/mfx_mpeg2_encode_interface.h
@@ -117,7 +117,7 @@ namespace MfxHwMpeg2Encode
 
         VAIQMatrixBufferMPEG2                   m_quantMatrix;
 
-        mfxHDL                                  m_pSurface;
+        mfxFrameSurface1*                       m_pSurface;
         mfxHDLPair                              m_pSurfacePair;
 
         DWORD                                   m_idxMb;

--- a/_studio/mfx_lib/shared/src/mfx_mpeg2_encode_vaapi.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_mpeg2_encode_vaapi.cpp
@@ -1458,11 +1458,11 @@ mfxStatus VAAPIEncoder::SetFrames (ExecuteBuffers* pExecuteBuffers)
     }
     else if (pExecuteBuffers->m_bExternalCurrFrame)
     {
-        sts = m_core->GetExternalFrameHDL(pExecuteBuffers->m_CurrFrameMemID,(mfxHDL *)&pExecuteBuffers->m_pSurface);
+        sts = m_core->GetExternalFrameHDL(*pExecuteBuffers->m_pSurface, pExecuteBuffers->m_pSurfacePair);
     }
     else
     {
-        sts = m_core->GetFrameHDL(pExecuteBuffers->m_CurrFrameMemID,(mfxHDL *)&pExecuteBuffers->m_pSurface);
+        sts = m_core->GetFrameHDL(*pExecuteBuffers->m_pSurface, pExecuteBuffers->m_pSurfacePair);
     }
     MFX_CHECK_STS(sts);
 


### PR DESCRIPTION
Issue: MDP-66735
Tests: smt_mjpegd_mixe_1_n_async_ext-memory2