### PR TITLE
[hevce/lib] Remove 422 VDEnc restriction

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy_defaults.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy_defaults.cpp
@@ -441,8 +441,7 @@ public:
         auto fcc = par.mvp.mfx.FrameInfo.FourCC;
         bool bMax420 =
             fcc == MFX_FOURCC_NV12
-            || fcc == MFX_FOURCC_P010
-            || (IsOn(par.mvp.mfx.LowPower) && (fcc == MFX_FOURCC_Y210 || fcc == MFX_FOURCC_YUY2));
+            || fcc == MFX_FOURCC_P010;
 
         bool bMax422 =
             fcc == MFX_FOURCC_YUY2

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_caps.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/g12/hevcehw_g12_caps.cpp
@@ -83,7 +83,7 @@ void Caps::Query1WithCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
         caps.SliceIPOnly                = IsOn(par.mfx.LowPower) && par.mfx.CodecProfile == MFX_PROFILE_HEVC_SCC;
         caps.msdk.bSingleSliceMultiTile = false;
 
-        caps.YUV422ReconSupport &= (!caps.Color420Only && !IsOn(par.mfx.LowPower));
+        caps.YUV422ReconSupport &= !caps.Color420Only;
 
         SetSpecificCaps(caps);
 


### PR DESCRIPTION
Remove vdenc422 restriction here, maxChroma can be controlled
by platform caps YUV422ReconSupport reported from driver.