### PR TITLE
[AVCe] Correct VA Interlaced caps reading

### DIFF
--- a/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
+++ b/_studio/mfx_lib/shared/src/mfx_h264_encode_vaapi.cpp
@@ -1638,10 +1638,7 @@ mfxStatus VAAPIEncoder::CreateAuxilliaryDevice(
         m_caps.ddi_caps.SliceStructure = (hwtype != MFX_HW_VLV && hwtype >= MFX_HW_HSW) ? 4 : 1; // 1 - SliceDividerSnb; 2 - SliceDividerHsw;
     }                                                                                   // 3 - SliceDividerBluRay; 4 - arbitrary slice size in MBs; the other - SliceDividerOneSlice
 
-    if (AV(VAConfigAttribEncInterlaced) != VA_ATTRIB_NOT_SUPPORTED)
-        m_caps.ddi_caps.NoInterlacedField = AV(VAConfigAttribEncInterlaced);
-    else
-        m_caps.ddi_caps.NoInterlacedField = 0;
+    m_caps.ddi_caps.NoInterlacedField = !(AV(VAConfigAttribEncInterlaced) & VA_ENC_INTERLACED_FIELD); // 0 - Interlace is supported, 1 - Interlace is not supported
 
     if (AV(VAConfigAttribEncMaxRefFrames) != VA_ATTRIB_NOT_SUPPORTED)
     {


### PR DESCRIPTION
Previously DDI caps for interlace were confused,
for VA_ENC_INTERLACED_FIELD (==2) ddi_caps.NoInterlacedField was set to 1,
which means that interlaced field IS NOT supported, and vice versa,

for VA_ENC_INTERLACED_NONE (==0) ddi_caps.NoInterlacedField was set to 0,
which means that interlaced field IS supported.