### PR TITLE
ci: support clang-12 and fix errors and warnings

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -6,6 +6,68 @@ env:
   CFLAGS: -O2 -Wformat -Wformat-security -Wall -Werror -D_FORTIFY_SOURCE=2 -fstack-protector-strong
 
 jobs:
+  clang12:
+    runs-on: ubuntu-20.04
+    env:
+      CC: /usr/bin/clang-12
+      CXX: /usr/bin/clang++-12
+      ASM: /usr/bin/clang-12
+    steps:
+    - name: checkout libmfxgen
+      uses: actions/checkout@v2
+      with:
+        path: libmfxgen
+    - name: checkout libva
+      uses: actions/checkout@v2
+      with:
+        repository: intel/libva
+        path: libva
+    - name: install toolchain
+      run: |
+        if [[ -e $CC && -e $CXX ]]; then \
+          echo "clang-12 already presents in the image"; \
+        else \
+          echo "clang-12 missed in the image, installing from llvm"; \
+          echo "deb [trusted=yes] http://apt.llvm.org/focal/ llvm-toolchain-focal-12 main" | sudo tee -a /etc/apt/sources.list; \
+          sudo apt-get update; \
+          sudo apt-get install -y --no-install-recommends clang-12; \
+        fi
+    - name: install prerequisites
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          cmake \
+          libdrm-dev \
+          libegl1-mesa-dev \
+          libgl1-mesa-dev \
+          libx11-dev \
+          libx11-xcb-dev \
+          libxcb-dri3-dev \
+          libxcb-present-dev \
+          libxext-dev \
+          libxfixes-dev \
+          libwayland-dev \
+          ninja-build \
+          make
+    - name: print tools versions
+      run: |
+        cmake --version
+        $CC --version
+        $CXX --version
+    - name: build libva
+      run: |
+        cd libva
+        ./autogen.sh --prefix=/usr --libdir=/usr/lib/x86_64-linux-gnu
+        make -j$(nproc)
+        sudo make install
+    - name: build libmfxgen
+      run: |
+        cd libmfxgen
+        mkdir build && cd build
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS_RELEASE="$CFLAGS" -DCMAKE_CXX_FLAGS_RELEASE="$CFLAGS" ..
+        ninja
+        sudo ninja install
+
   gcc10:
     runs-on: ubuntu-20.04
     env:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,13 +2,14 @@ name: ubuntu-20.04
 
 on: [ push, pull_request ]
 
-env:
-  CFLAGS: -O2 -Wformat -Wformat-security -Wall -Werror -D_FORTIFY_SOURCE=2 -fstack-protector-strong
+#env:
+#  CFLAGS: -O2 -Wformat -Wformat-security -Wall -Werror -D_FORTIFY_SOURCE=2 -fstack-protector-strong
 
 jobs:
   clang12:
     runs-on: ubuntu-20.04
     env:
+      CFLAGS: -O2 -Wformat -Wformat-security -Wall -Werror -Wno-overloaded-virtual -D_FORTIFY_SOURCE=2 -fstack-protector-strong
       CC: /usr/bin/clang-12
       CXX: /usr/bin/clang++-12
       ASM: /usr/bin/clang-12
@@ -71,6 +72,7 @@ jobs:
   gcc10:
     runs-on: ubuntu-20.04
     env:
+      CFLAGS: -O2 -Wformat -Wformat-security -Wall -Werror -D_FORTIFY_SOURCE=2 -fstack-protector-strong
       CC: /usr/bin/gcc-10
       CXX: /usr/bin/g++-10
       ASM: /usr/bin/gcc-10

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,9 @@
 cmake_minimum_required( VERSION 3.14 )
 
 cmake_policy(SET CMP0048 NEW)   # version handled by project()
+if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.15)
 cmake_policy(SET CMP0092 NEW)   # we handle warning level programmaticaly
+endif()
 
 
 # Througout this project MFX_VERSION refers to uAPI version and MEDIA_VERSION refers to product version

--- a/_studio/mfx_lib/decode/h264/include/mfx_h264_dec_decode.h
+++ b/_studio/mfx_lib/decode/h264/include/mfx_h264_dec_decode.h
@@ -63,19 +63,19 @@ public:
     VideoDECODEH264(VideoCORE *core, mfxStatus * sts);
     virtual ~VideoDECODEH264(void);
 
-    mfxStatus Init(mfxVideoParam *par);
-    virtual mfxStatus Reset(mfxVideoParam *par);
-    virtual mfxStatus Close(void);
-    virtual mfxTaskThreadingPolicy GetThreadingPolicy(void);
+    mfxStatus Init(mfxVideoParam *par) override;
+    virtual mfxStatus Reset(mfxVideoParam *par) override;
+    virtual mfxStatus Close(void) override;
+    virtual mfxTaskThreadingPolicy GetThreadingPolicy(void) override;
 
-    virtual mfxStatus GetVideoParam(mfxVideoParam *par);
-    virtual mfxStatus GetDecodeStat(mfxDecodeStat *stat);
+    virtual mfxStatus GetVideoParam(mfxVideoParam *par) override;
+    virtual mfxStatus GetDecodeStat(mfxDecodeStat *stat) override;
 
-    virtual mfxStatus DecodeFrameCheck(mfxBitstream *bs, mfxFrameSurface1 *surface_work, mfxFrameSurface1 **surface_out, MFX_ENTRY_POINT *pEntryPoint);
+    virtual mfxStatus DecodeFrameCheck(mfxBitstream *bs, mfxFrameSurface1 *surface_work, mfxFrameSurface1 **surface_out, MFX_ENTRY_POINT *pEntryPoint) override;
     virtual mfxStatus DecodeFrame(mfxBitstream *bs, mfxFrameSurface1 *surface_work, mfxFrameSurface1 *surface_out);
     virtual mfxStatus GetUserData(mfxU8 *ud, mfxU32 *sz, mfxU64 *ts);
-    virtual mfxStatus GetPayload(mfxU64 *ts, mfxPayload *payload);
-    virtual mfxStatus SetSkipMode(mfxSkipMode mode);
+    virtual mfxStatus GetPayload(mfxU64 *ts, mfxPayload *payload) override;
+    virtual mfxStatus SetSkipMode(mfxSkipMode mode) override;
 
     mfxStatus RunThread(ThreadTaskInfo*, mfxU32 /*threadNumber*/);
 
@@ -102,7 +102,7 @@ protected:
 
 
     mfxFrameSurface1 * GetOriginalSurface(mfxFrameSurface1 *surface);
-    mfxFrameSurface1 * GetInternalSurface(mfxFrameSurface1 *surface);
+    mfxFrameSurface1 * GetInternalSurface(mfxFrameSurface1 *surface) override;
     std::unique_ptr<UMC::MFXTaskSupplier>  m_pH264VideoDecoder;
     mfx_UMC_MemAllocator                   m_MemoryAllocator;
 

--- a/_studio/mfx_lib/decode/h265/include/mfx_h265_dec_decode.h
+++ b/_studio/mfx_lib/decode/h265/include/mfx_h265_dec_decode.h
@@ -68,28 +68,28 @@ public:
     virtual ~VideoDECODEH265(void);
 
     // Initialize decoder instance
-    mfxStatus Init(mfxVideoParam *par);
+    mfxStatus Init(mfxVideoParam *par) override;
     // Reset decoder with new parameters
-    virtual mfxStatus Reset(mfxVideoParam *par);
+    virtual mfxStatus Reset(mfxVideoParam *par) override;
     // Free decoder resources
-    virtual mfxStatus Close(void);
+    virtual mfxStatus Close(void) override;
     // Returns decoder threading mode
-    virtual mfxTaskThreadingPolicy GetThreadingPolicy(void);
+    virtual mfxTaskThreadingPolicy GetThreadingPolicy(void) override;
 
     // MediaSDK DECODE_GetVideoParam API function
-    virtual mfxStatus GetVideoParam(mfxVideoParam *par);
+    virtual mfxStatus GetVideoParam(mfxVideoParam *par) override;
     // MediaSDK DECODE_GetDecodeStat API function
-    virtual mfxStatus GetDecodeStat(mfxDecodeStat *stat);
+    virtual mfxStatus GetDecodeStat(mfxDecodeStat *stat) override;
     // Initialize threads callbacks
-    virtual mfxStatus DecodeFrameCheck(mfxBitstream *bs, mfxFrameSurface1 *surface_work, mfxFrameSurface1 **surface_out, MFX_ENTRY_POINT *pEntryPoint);
+    virtual mfxStatus DecodeFrameCheck(mfxBitstream *bs, mfxFrameSurface1 *surface_work, mfxFrameSurface1 **surface_out, MFX_ENTRY_POINT *pEntryPoint) override;
     // Wait until a frame is ready to be output and set necessary surface flags
     virtual mfxStatus DecodeFrame(mfxBitstream *bs, mfxFrameSurface1 *surface_work, mfxFrameSurface1 *surface_out);
     // Returns closed caption data
     virtual mfxStatus GetUserData(mfxU8 *ud, mfxU32 *sz, mfxU64 *ts);
     // Returns stored SEI messages
-    virtual mfxStatus GetPayload(mfxU64 *ts, mfxPayload *payload);
+    virtual mfxStatus GetPayload(mfxU64 *ts, mfxPayload *payload) override;
     // MediaSDK DECODE_SetSkipMode API function
-    virtual mfxStatus SetSkipMode(mfxSkipMode mode);
+    virtual mfxStatus SetSkipMode(mfxSkipMode mode) override;
 
     // Decoder instance threads entry point. Do async tasks here
     mfxStatus RunThread(void * params, mfxU32 threadNumber);

--- a/_studio/mfx_lib/decode/mjpeg/include/mfx_mjpeg_dec_decode.h
+++ b/_studio/mfx_lib/decode/mjpeg/include/mfx_mjpeg_dec_decode.h
@@ -174,19 +174,19 @@ public:
     VideoDECODEMJPEG(VideoCORE *core, mfxStatus * sts);
     virtual ~VideoDECODEMJPEG(void);
 
-    mfxStatus Init(mfxVideoParam *par);
-    virtual mfxStatus Reset(mfxVideoParam *par);
-    virtual mfxStatus Close(void);
-    virtual mfxTaskThreadingPolicy GetThreadingPolicy(void);
+    mfxStatus Init(mfxVideoParam *par) override;
+    virtual mfxStatus Reset(mfxVideoParam *par) override;
+    virtual mfxStatus Close(void) override;
+    virtual mfxTaskThreadingPolicy GetThreadingPolicy(void) override;
 
-    virtual mfxStatus GetVideoParam(mfxVideoParam *par);
-    virtual mfxStatus GetDecodeStat(mfxDecodeStat *stat);
+    virtual mfxStatus GetVideoParam(mfxVideoParam *par) override;
+    virtual mfxStatus GetDecodeStat(mfxDecodeStat *stat) override;
     virtual mfxStatus DecodeFrameCheck(mfxBitstream *bs, mfxFrameSurface1 *surface_work, mfxFrameSurface1 **surface_out);
-    virtual mfxStatus DecodeFrameCheck(mfxBitstream *bs, mfxFrameSurface1 *surface_work, mfxFrameSurface1 **surface_out, MFX_ENTRY_POINT *pEntryPoint);
+    virtual mfxStatus DecodeFrameCheck(mfxBitstream *bs, mfxFrameSurface1 *surface_work, mfxFrameSurface1 **surface_out, MFX_ENTRY_POINT *pEntryPoint) override;
     virtual mfxStatus DecodeFrame(mfxBitstream *bs, mfxFrameSurface1 *surface_work, mfxFrameSurface1 *surface_out);
     virtual mfxStatus GetUserData(mfxU8 *ud, mfxU32 *sz, mfxU64 *ts);
-    virtual mfxStatus GetPayload(mfxU64 *ts, mfxPayload *payload);
-    virtual mfxStatus SetSkipMode(mfxSkipMode mode);
+    virtual mfxStatus GetPayload(mfxU64 *ts, mfxPayload *payload) override;
+    virtual mfxStatus SetSkipMode(mfxSkipMode mode) override;
 
     virtual mfxFrameSurface1* GetSurface() override;
 

--- a/_studio/mfx_lib/decode/vc1/include/mfx_vc1_decode.h
+++ b/_studio/mfx_lib/decode/vc1/include/mfx_vc1_decode.h
@@ -71,25 +71,25 @@ public:
     virtual ~MFXVideoDECODEVC1(void);
 
 
-    mfxStatus Init(mfxVideoParam *par);
-    virtual mfxStatus Reset(mfxVideoParam *par);
-    virtual mfxStatus Close(void);
-    virtual mfxTaskThreadingPolicy GetThreadingPolicy(void);
+    mfxStatus Init(mfxVideoParam *par) override;
+    virtual mfxStatus Reset(mfxVideoParam *par) override;
+    virtual mfxStatus Close(void) override;
+    virtual mfxTaskThreadingPolicy GetThreadingPolicy(void) override;
 
-    virtual mfxStatus GetVideoParam(mfxVideoParam *par);
+    virtual mfxStatus GetVideoParam(mfxVideoParam *par) override;
 
     virtual mfxStatus GetUserData(mfxU8 *ud, mfxU32 *sz, mfxU64 *ts);
 
-    virtual mfxStatus GetDecodeStat(mfxDecodeStat *stat);
+    virtual mfxStatus GetDecodeStat(mfxDecodeStat *stat) override;
 
     virtual mfxStatus DecodeFrameCheck(mfxBitstream *bs,
                                        mfxFrameSurface1 *surface_work,
                                        mfxFrameSurface1 **surface_out,
-                                       MFX_ENTRY_POINT *pEntryPoint);
+                                       MFX_ENTRY_POINT *pEntryPoint) override;
 
     virtual mfxStatus DecodeFrameCheck(mfxBitstream *bs, mfxFrameSurface1 *surface_work, mfxFrameSurface1 **surface_disp);
-    virtual mfxStatus SetSkipMode(mfxSkipMode mode);
-    virtual mfxStatus GetPayload(mfxU64 *ts, mfxPayload *payload);
+    virtual mfxStatus SetSkipMode(mfxSkipMode mode) override;
+    virtual mfxStatus GetPayload(mfxU64 *ts, mfxPayload *payload) override;
     // to satisfy internal API
     virtual mfxStatus DecodeFrame(mfxBitstream * /*bs*/, mfxFrameSurface1 * /*surface_work*/, mfxFrameSurface1 * /*surface_out*/){ return MFX_ERR_UNSUPPORTED; };
 

--- a/_studio/mfx_lib/decode/vp8/include/mfx_vp8_dec_decode_hw.h
+++ b/_studio/mfx_lib/decode/vp8/include/mfx_vp8_dec_decode_hw.h
@@ -177,21 +177,21 @@ public:
     static mfxStatus QueryIOSurf(VideoCORE *pCore, mfxVideoParam *pPar, mfxFrameAllocRequest *pRequest);
     static mfxStatus QueryImplsDescription(VideoCORE&, mfxDecoderDescription::decoder&, mfx::PODArraysHolder&);
 
-    virtual mfxStatus Init(mfxVideoParam *pPar);
-    virtual mfxStatus Reset(mfxVideoParam *pPar);
-    virtual mfxStatus Close();
+    virtual mfxStatus Init(mfxVideoParam *pPar) override;
+    virtual mfxStatus Reset(mfxVideoParam *pPar) override;
+    virtual mfxStatus Close() override;
 
-    virtual mfxTaskThreadingPolicy GetThreadingPolicy();
-    virtual mfxStatus GetVideoParam(mfxVideoParam *pPar);
-    virtual mfxStatus GetDecodeStat(mfxDecodeStat *pStat);
+    virtual mfxTaskThreadingPolicy GetThreadingPolicy() override;
+    virtual mfxStatus GetVideoParam(mfxVideoParam *pPar) override;
+    virtual mfxStatus GetDecodeStat(mfxDecodeStat *pStat) override;
 
     virtual mfxStatus DecodeFrameCheck(mfxBitstream *bs, mfxFrameSurface1 *surface_work, mfxFrameSurface1 **surface_out);
-    virtual mfxStatus DecodeFrameCheck(mfxBitstream *pBs, mfxFrameSurface1 *pSurfaceWork, mfxFrameSurface1 **ppSurfaceOut, MFX_ENTRY_POINT *pEntryPoint);
+    virtual mfxStatus DecodeFrameCheck(mfxBitstream *pBs, mfxFrameSurface1 *pSurfaceWork, mfxFrameSurface1 **ppSurfaceOut, MFX_ENTRY_POINT *pEntryPoint) override;
     virtual mfxStatus DecodeFrame(mfxBitstream *pBs, mfxFrameSurface1 *pSurfaceWork, mfxFrameSurface1 *pSurfaceOut);
 
     virtual mfxStatus GetUserData(mfxU8 *pUserData, mfxU32 *pSize, mfxU64 *pTimeStamp);
-    virtual mfxStatus GetPayload(mfxU64 *pTimeStamp, mfxPayload *pPayload);
-    virtual mfxStatus SetSkipMode(mfxSkipMode mode);
+    virtual mfxStatus GetPayload(mfxU64 *pTimeStamp, mfxPayload *pPayload) override;
+    virtual mfxStatus SetSkipMode(mfxSkipMode mode) override;
 
     virtual mfxFrameSurface1* GetSurface() override;
 

--- a/_studio/mfx_lib/decode/vp9/include/mfx_vp9_dec_decode_hw.h
+++ b/_studio/mfx_lib/decode/vp9/include/mfx_vp9_dec_decode_hw.h
@@ -61,20 +61,20 @@ public:
     static mfxStatus QueryIOSurf(VideoCORE *pCore, mfxVideoParam *pPar, mfxFrameAllocRequest *pRequest);
     static mfxStatus QueryImplsDescription(VideoCORE&, mfxDecoderDescription::decoder&, mfx::PODArraysHolder&);
 
-    virtual mfxStatus Init(mfxVideoParam *par);
-    virtual mfxStatus Reset(mfxVideoParam *pPar);
-    virtual mfxStatus Close();
+    virtual mfxStatus Init(mfxVideoParam *par) override;
+    virtual mfxStatus Reset(mfxVideoParam *pPar) override;
+    virtual mfxStatus Close() override;
 
-    virtual mfxTaskThreadingPolicy GetThreadingPolicy();
-    virtual mfxStatus GetVideoParam(mfxVideoParam *pPar);
-    virtual mfxStatus GetDecodeStat(mfxDecodeStat *pStat);
+    virtual mfxTaskThreadingPolicy GetThreadingPolicy() override;
+    virtual mfxStatus GetVideoParam(mfxVideoParam *pPar) override;
+    virtual mfxStatus GetDecodeStat(mfxDecodeStat *pStat) override;
 
     static mfxStatus DecodeHeader(VideoCORE * core, mfxBitstream *bs, mfxVideoParam *params);
-    virtual mfxStatus DecodeFrameCheck(mfxBitstream *bs, mfxFrameSurface1 *pSurfaceWork, mfxFrameSurface1 **ppSurfaceOut, MFX_ENTRY_POINT *pEntryPoint);
+    virtual mfxStatus DecodeFrameCheck(mfxBitstream *bs, mfxFrameSurface1 *pSurfaceWork, mfxFrameSurface1 **ppSurfaceOut, MFX_ENTRY_POINT *pEntryPoint) override;
 
     virtual mfxStatus GetUserData(mfxU8 *pUserData, mfxU32 *pSize, mfxU64 *pTimeStamp);
-    virtual mfxStatus GetPayload(mfxU64 *pTimeStamp, mfxPayload *pPayload);
-    virtual mfxStatus SetSkipMode(mfxSkipMode mode);
+    virtual mfxStatus GetPayload(mfxU64 *pTimeStamp, mfxPayload *pPayload) override;
+    virtual mfxStatus SetSkipMode(mfxSkipMode mode) override;
 
     virtual mfxFrameSurface1* GetSurface() override;
 

--- a/_studio/mfx_lib/shared/include/mfx_h264_encode_vaapi.h
+++ b/_studio/mfx_lib/shared/include/mfx_h264_encode_vaapi.h
@@ -172,7 +172,7 @@ namespace MfxHwH264Encode
         virtual
         mfxStatus Destroy() override;
 
-        void ForceCodingFunction (mfxU16 /*codingFunction*/)
+        void ForceCodingFunction (mfxU16 /*codingFunction*/) override
         {
             // no need in it on Linux
         }

--- a/_studio/mfx_lib/shared/src/libmfxsw.cpp
+++ b/_studio/mfx_lib/shared/src/libmfxsw.cpp
@@ -516,7 +516,7 @@ mfxHDL* MFX_CDECL MFXQueryImplsDescription(mfxImplCapsDeliveryFormat format, mfx
             auto& impl = holder->PushBack();
 
             impl.Impl             = MFX_IMPL_TYPE_HARDWARE;
-            impl.ApiVersion       = { MFX_VERSION_MINOR, MFX_VERSION_MAJOR };
+            impl.ApiVersion       = { { MFX_VERSION_MINOR, MFX_VERSION_MAJOR } };
             impl.VendorID         = 0x8086;
             // use adapterNum as VendorImplID, app. supposed just to copy it from mfxImplDescription to mfxInitializationParam
             impl.VendorImplID     = adapterNum;

--- a/_studio/mfx_lib/vpp/include/mfx_vpp_main.h
+++ b/_studio/mfx_lib/vpp/include/mfx_vpp_main.h
@@ -47,10 +47,10 @@ public:
     virtual ~VideoVPPMain();
 
     // VideoVPP
-    virtual mfxStatus RunFrameVPP(mfxFrameSurface1 *in, mfxFrameSurface1 *out, mfxExtVppAuxData *aux);
+    virtual mfxStatus RunFrameVPP(mfxFrameSurface1 *in, mfxFrameSurface1 *out, mfxExtVppAuxData *aux) override;
 
     // VideoBase methods
-    virtual mfxStatus Reset(mfxVideoParam *par)
+    virtual mfxStatus Reset(mfxVideoParam *par) override
     {
         MFX_CHECK_NULL_PTR1( par );
 
@@ -59,40 +59,40 @@ public:
             : MFX_ERR_NOT_INITIALIZED;
     }
 
-    virtual mfxStatus Close(void);
+    virtual mfxStatus Close(void) override;
 
-    virtual mfxStatus Init(mfxVideoParam *par);
+    virtual mfxStatus Init(mfxVideoParam *par) override;
 
-    virtual mfxStatus GetVideoParam(mfxVideoParam *par)
+    virtual mfxStatus GetVideoParam(mfxVideoParam *par) override
     {
         return m_impl.get()
             ? m_impl->GetVideoParam(par)
             : MFX_ERR_NOT_INITIALIZED;
     }
 
-    virtual mfxStatus GetVPPStat(
-        mfxVPPStat *stat)
+    virtual mfxStatus GetVPPStat (
+        mfxVPPStat *stat) override
     {
         return m_impl.get()
             ? m_impl->GetVPPStat(stat)
             : MFX_ERR_NOT_INITIALIZED;
     }
 
-    virtual mfxStatus VppFrameCheck(
+    virtual mfxStatus VppFrameCheck (
         mfxFrameSurface1 *in,
         mfxFrameSurface1 *out,
         mfxExtVppAuxData *aux,
         MFX_ENTRY_POINT pEntryPoint[],
-        mfxU32 &numEntryPoints);
+        mfxU32 &numEntryPoints) override;
 
     virtual mfxStatus VppFrameCheck(
         mfxFrameSurface1 *,
-        mfxFrameSurface1 *)
+        mfxFrameSurface1 *) override
     {
         return MFX_ERR_UNSUPPORTED;
     }
 
-    virtual mfxTaskThreadingPolicy GetThreadingPolicy(void);
+    virtual mfxTaskThreadingPolicy GetThreadingPolicy(void) override;
 
     // multi threading of SW_VPP functions
     mfxStatus RunVPPTask(

--- a/_studio/mfx_lib/vpp/include/mfx_vpp_sw.h
+++ b/_studio/mfx_lib/vpp/include/mfx_vpp_sw.h
@@ -126,16 +126,16 @@ class VideoVPP_HW : public VideoVPPBase
 public:
     VideoVPP_HW(VideoCORE *core, mfxStatus* sts);
 
-    virtual mfxStatus InternalInit(mfxVideoParam *par);
-    virtual mfxStatus Close(void);
-    virtual mfxStatus Reset(mfxVideoParam *par);
+    virtual mfxStatus InternalInit(mfxVideoParam *par) override;
+    virtual mfxStatus Close(void) override;
+    virtual mfxStatus Reset(mfxVideoParam *par) override;
 
-    virtual mfxStatus GetVideoParam(mfxVideoParam *par);
+    virtual mfxStatus GetVideoParam(mfxVideoParam *par) override;
 
     virtual mfxStatus VppFrameCheck(mfxFrameSurface1 *in, mfxFrameSurface1 *out, mfxExtVppAuxData *aux,
-                                    MFX_ENTRY_POINT pEntryPoints[], mfxU32 &numEntryPoints);
+                                    MFX_ENTRY_POINT pEntryPoints[], mfxU32 &numEntryPoints) override;
 
-    virtual mfxStatus RunFrameVPP(mfxFrameSurface1* in, mfxFrameSurface1* out, mfxExtVppAuxData *aux);
+    virtual mfxStatus RunFrameVPP(mfxFrameSurface1* in, mfxFrameSurface1* out, mfxExtVppAuxData *aux) override;
 
     mfxStatus PassThrough(mfxFrameInfo* In, mfxFrameInfo* Out, mfxU32 taskIndex);
 

--- a/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
+++ b/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
@@ -6855,7 +6855,7 @@ mfxStatus CopyFrameDataBothFields(
     FrameLocker lock2(core, srcSurf->Data, true);
     MFX_CHECK(srcSurf->Data.Y != 0, MFX_ERR_LOCK_MEMORY);
 
-    mfxFrameData dstData = { 0 };
+    mfxFrameData dstData{};
     MFX_AUTO_LTRACE(MFX_TRACE_LEVEL_INTERNAL, "Surface lock (output frame)");
     FrameLocker lock(core, dstData, dstMid);
     MFX_CHECK(dstData.Y != 0, MFX_ERR_LOCK_MEMORY);

--- a/_studio/shared/include/libmfx_allocator.h
+++ b/_studio/shared/include/libmfx_allocator.h
@@ -639,7 +639,7 @@ public:
     }
 
 private:
-    std::atomic<size_t>                    m_last_created_mid = 0;
+    std::atomic<size_t>                    m_last_created_mid = { 0 };
     mfxHDL                                 m_device           = nullptr;
 
     mutable std::shared_timed_mutex        m_mutex;

--- a/_studio/shared/include/mfx_umc_alloc_wrapper.h
+++ b/_studio/shared/include/mfx_umc_alloc_wrapper.h
@@ -50,24 +50,24 @@ public:
     virtual UMC::Status InitMem(UMC::MemoryAllocatorParams *pParams, VideoCORE* mfxCore);
 
     // Closes object and releases all allocated memory
-    virtual UMC::Status Close();
+    virtual UMC::Status Close() override;
 
     // Allocates or reserves physical memory and return unique ID
     // Sets lock counter to 0
-    virtual UMC::Status Alloc(UMC::MemID *pNewMemID, size_t Size, uint32_t Flags, uint32_t Align = 16);
+    virtual UMC::Status Alloc(UMC::MemID *pNewMemID, size_t Size, uint32_t Flags, uint32_t Align = 16) override;
 
     // Lock() provides pointer from ID. If data is not in memory (swapped)
     // prepares (restores) it. Increases lock counter
-    virtual void *Lock(UMC::MemID MID);
+    virtual void *Lock(UMC::MemID MID) override;
 
     // Unlock() decreases lock counter
-    virtual UMC::Status Unlock(UMC::MemID MID);
+    virtual UMC::Status Unlock(UMC::MemID MID) override;
 
     // Notifies that the data wont be used anymore. Memory can be free
-    virtual UMC::Status Free(UMC::MemID MID);
+    virtual UMC::Status Free(UMC::MemID MID) override;
 
     // Immediately deallocates memory regardless of whether it is in use (locked) or no
-    virtual UMC::Status DeallocateMem(UMC::MemID MID);
+    virtual UMC::Status DeallocateMem(UMC::MemID MID) override;
 
 protected:
     VideoCORE* m_pCore;
@@ -99,28 +99,28 @@ public:
                                 bool isSWplatform);
 
     // Closes object and releases all allocated memory
-    virtual UMC::Status Close();
+    virtual UMC::Status Close() override;
 
     // Allocates or reserves physical memory and returns unique ID
     // Sets lock counter to 0
-    virtual UMC::Status Alloc(UMC::FrameMemID *pNewMemID, const UMC::VideoDataInfo * info, uint32_t flags);
+    virtual UMC::Status Alloc(UMC::FrameMemID *pNewMemID, const UMC::VideoDataInfo * info, uint32_t flags) override;
 
-    virtual UMC::Status GetFrameHandle(UMC::FrameMemID memId, void * handle);
+    virtual UMC::Status GetFrameHandle(UMC::FrameMemID memId, void * handle) override;
 
     // Lock() provides pointer from ID. If data is not in memory (swapped)
     // prepares (restores) it. Increases lock counter
-    virtual const UMC::FrameData* Lock(UMC::FrameMemID mid);
+    virtual const UMC::FrameData* Lock(UMC::FrameMemID mid) override;
 
     // Unlock() decreases lock counter
-    virtual UMC::Status Unlock(UMC::FrameMemID mid);
+    virtual UMC::Status Unlock(UMC::FrameMemID mid) override;
 
     // Notifies that the data won't be used anymore. Memory can be freed.
-    virtual UMC::Status IncreaseReference(UMC::FrameMemID mid);
+    virtual UMC::Status IncreaseReference(UMC::FrameMemID mid) override;
 
     // Notifies that the data won't be used anymore. Memory can be freed.
-    virtual UMC::Status DecreaseReference(UMC::FrameMemID mid);
+    virtual UMC::Status DecreaseReference(UMC::FrameMemID mid) override;
 
-    virtual UMC::Status Reset();
+    virtual UMC::Status Reset() override;
 
     virtual mfxStatus SetCurrentMFXSurface(mfxFrameSurface1 *srf, bool isOpaq);
 
@@ -377,7 +377,7 @@ public:
                                 const mfxFrameAllocRequest *request, 
                                 mfxFrameAllocResponse *response, 
                                 bool isUseExternalFrames,
-                                bool isSWplatform);
+                                bool isSWplatform) override;
 
     // suppose that Close() calls Reset(), so override only Reset()
     virtual UMC::Status Reset() override;

--- a/_studio/shared/umc/codec/color_space_converter/include/umc_color_space_conversion.h
+++ b/_studio/shared/umc/codec/color_space_converter/include/umc_color_space_conversion.h
@@ -31,19 +31,19 @@ class ColorSpaceConversion : public BaseCodec
   DYNAMIC_CAST_DECL(ColorSpaceConversion, BaseCodec)
 public:
   // Initialize codec with specified parameter(s)
-  virtual Status Init(BaseCodecParams *) { return UMC_OK; };
+  virtual Status Init(BaseCodecParams *) override { return UMC_OK; };
 
   // Convert next frame
-  virtual Status GetFrame(MediaData *in, MediaData *out);
+  virtual Status GetFrame(MediaData *in, MediaData *out) override;
 
   // Get codec working (initialization) parameter(s)
-  virtual Status GetInfo(BaseCodecParams *) { return UMC_OK; };
+  virtual Status GetInfo(BaseCodecParams *) override { return UMC_OK; };
 
   // Close all codec resources
-  virtual Status Close(void) { return UMC_OK; };
+  virtual Status Close(void) override { return UMC_OK; };
 
   // Set codec to initial state
-  virtual Status Reset(void) { return UMC_OK; };
+  virtual Status Reset(void) override { return UMC_OK; };
 
 private:
   Status GetFrameInternal(MediaData *in, MediaData *out);

--- a/_studio/shared/umc/codec/color_space_converter/include/umc_deinterlacing.h
+++ b/_studio/shared/umc/codec/color_space_converter/include/umc_deinterlacing.h
@@ -38,19 +38,19 @@ public:
   virtual Status SetMethod(DeinterlacingMethod method);
 
   // Initialize codec with specified parameter(s)
-  virtual Status Init(BaseCodecParams *) { return UMC_OK; };
+  virtual Status Init(BaseCodecParams *) override { return UMC_OK; };
 
   // Convert frame
-  virtual Status GetFrame(MediaData *in, MediaData *out);
+  virtual Status GetFrame(MediaData *in, MediaData *out) override;
 
   // Get codec working (initialization) parameter(s)
-  virtual Status GetInfo(BaseCodecParams *) { return UMC_OK; };
+  virtual Status GetInfo(BaseCodecParams *) override { return UMC_OK; };
 
   // Close all codec resources
-  virtual Status Close(void) { return UMC_OK; };
+  virtual Status Close(void) override { return UMC_OK; };
 
   // Set codec to initial state
-  virtual Status Reset(void) { return UMC_OK; };
+  virtual Status Reset(void) override { return UMC_OK; };
 
 protected:
   DeinterlacingMethod mMethod;

--- a/_studio/shared/umc/codec/color_space_converter/include/umc_video_processing.h
+++ b/_studio/shared/umc/codec/color_space_converter/include/umc_video_processing.h
@@ -69,7 +69,7 @@ class VideoDataExt : public VideoData
 {
   DYNAMIC_CAST_DECL(VideoDataExt, VideoData)
 public:
-  Status Crop(UMC::sRECT SrcCropArea);
+  Status Crop(UMC::sRECT SrcCropArea) override;
   Status Convert_YV12_To_YUV420();
 };
 
@@ -84,17 +84,17 @@ public:
   VideoProcessing();
   virtual ~VideoProcessing();
 
-  virtual Status Init(BaseCodecParams *init);
+  virtual Status Init(BaseCodecParams *init) override;
 
   virtual Status AddFilter(BaseCodec *filter, int atEnd);
 
-  virtual Status GetFrame(MediaData *input, MediaData *output);
+  virtual Status GetFrame(MediaData *input, MediaData *output) override;
 
-  virtual Status GetInfo(BaseCodecParams *info);
+  virtual Status GetInfo(BaseCodecParams *info) override;
 
-  virtual Status Close(void);
+  virtual Status Close(void) override;
 
-  virtual Status Reset(void);
+  virtual Status Reset(void) override;
 
   virtual Status SetParams(BaseCodecParams *params);
 

--- a/_studio/shared/umc/codec/h264_dec/include/umc_h264_frame.h
+++ b/_studio/shared/umc/codec/h264_dec/include/umc_h264_frame.h
@@ -156,7 +156,7 @@ public:
 
     void OnDecodingCompleted();
 
-    virtual void Free();
+    virtual void Free() override;
 
     void SetSkipped(bool isSkipped)
     {

--- a/_studio/shared/umc/core/umc/include/umc_dynamic_cast.h
+++ b/_studio/shared/umc/core/umc/include/umc_dynamic_cast.h
@@ -56,14 +56,14 @@ typedef const char *(*pDynamicCastFunction)(void);
     /* declare function to obtain string with class name */ \
     static const char *__GetClassName(void) {return #class_name;} \
     /* strong casting - compare function adresses of classes */ \
-    virtual bool TryStrongCasting(pDynamicCastFunction pCandidateFunction) const \
+    virtual bool TryStrongCasting(pDynamicCastFunction pCandidateFunction) const override \
     { \
         if (pCandidateFunction == &class_name::__GetClassName) \
             return true; \
         return parent_class::TryStrongCasting(pCandidateFunction); \
     } \
     /* weak casting - compare names of classes */ \
-    virtual bool TryWeakCasting(pDynamicCastFunction pCandidateFunction) const \
+    virtual bool TryWeakCasting(pDynamicCastFunction pCandidateFunction) const override \
     { \
         if (0 == strcmp(#class_name, pCandidateFunction())) \
             return true; \

--- a/_studio/shared/umc/core/umc/include/umc_video_data.h
+++ b/_studio/shared/umc/core/umc/include/umc_video_data.h
@@ -128,7 +128,7 @@ public:
 
     // Allocate buffer for video data and initialize it.
     virtual
-    Status Alloc(size_t requredSize = 0);
+    Status Alloc(size_t requredSize = 0) override;
 
     // Reset all plane pointers, release memory if allocated by Alloc
     virtual
@@ -136,12 +136,12 @@ public:
 
     // Release video data and all internal memory. Inherited.
     virtual
-    Status Close(void);
+    Status Close(void) override;
 
     // Set buffer pointer, assign all pointers. Inherited.
     // VideoData parameters must have been prepared
     virtual
-    Status SetBufferPointer(uint8_t *pbBuffer, size_t nSize);
+    Status SetBufferPointer(uint8_t *pbBuffer, size_t nSize) override;
 
     // Set common Alignment
     Status SetAlignment(int32_t iAlignment);

--- a/_studio/shared/umc/core/umc/include/umc_video_decoder.h
+++ b/_studio/shared/umc/core/umc/include/umc_video_decoder.h
@@ -66,7 +66,7 @@ public:
 
     // BaseCodec methods
     // Get codec working (initialization) parameter(s)
-    virtual Status GetInfo(BaseCodecParams *info);
+    virtual Status GetInfo(BaseCodecParams *info) override;
     // Set new working parameter(s)
     virtual Status SetParams(BaseCodecParams *params);
 


### PR DESCRIPTION
For: oneapi-src/oneVPL-intel-gpu#6

The following clang-12 warning still not addressed and got suppressed: `-Woverloaded-virtual`