### PR TITLE
wip: disable -Werror and -Wno-overloaded-virtual

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -9,7 +9,7 @@ jobs:
   clang12:
     runs-on: ubuntu-20.04
     env:
-      CFLAGS: -O2 -Wformat -Wformat-security -Wall -Werror -Wno-overloaded-virtual -D_FORTIFY_SOURCE=2 -fstack-protector-strong
+      CFLAGS: -O2 -Wformat -Wformat-security -Wall -D_FORTIFY_SOURCE=2 -fstack-protector-strong
       CC: /usr/bin/clang-12
       CXX: /usr/bin/clang++-12
       ASM: /usr/bin/clang-12


### PR DESCRIPTION
Disable -Werror and -Wno-overloaded-virtual to unhide -Woverloaded-virtual warning.