### PR TITLE
[VPP] clean MFX_ENABLE_VPP_FIELD_WEAVE_SPLIT to align with CS

### DIFF
--- a/_studio/shared/include/mfx_config.h
+++ b/_studio/shared/include/mfx_config.h
@@ -80,8 +80,6 @@
         #define MFX_ENABLE_VPP_RUNTIME_HSBC
     #endif
 
-    #undef MFX_ENABLE_VPP_FIELD_WEAVE_SPLIT
-
     //#define MFX_ENABLE_VPP_FRC
 #endif
 

--- a/_studio/shared/src/mfx_vpp_vaapi.cpp
+++ b/_studio/shared/src/mfx_vpp_vaapi.cpp
@@ -1323,7 +1323,6 @@ mfxStatus VAAPIVideoProcessing::Execute(mfxExecuteParams *pParams)
             break;
     }
 
-#if defined(MFX_ENABLE_VPP_FIELD_WEAVE_SPLIT)
     // If field weaving is perform on driver
     // Kernel don't uses these parameters
     if (pParams->bFieldWeavingExt)
@@ -1368,7 +1367,6 @@ mfxStatus VAAPIVideoProcessing::Execute(mfxExecuteParams *pParams)
             }
         }
     }
-#endif // MFX_ENABLE_VPP_FIELD_WEAVE_SPLIT
 
     m_pipelineParam[0].filters      = m_filterBufs;
     m_pipelineParam[0].num_filters  = m_numFilterBufs;


### PR DESCRIPTION
`#undef MFX_ENABLE_VPP_FIELD_WEAVE_SPLIT ` will lead to different results between OS and CS.