### PR TITLE
Revert "ci: wa no-overloaded-virtual"

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -2,14 +2,13 @@ name: ubuntu-20.04
 
 on: [ push, pull_request ]
 
-#env:
-#  CFLAGS: -O2 -Wformat -Wformat-security -Wall -Werror -D_FORTIFY_SOURCE=2 -fstack-protector-strong
+env:
+  CFLAGS: -O2 -Wformat -Wformat-security -Wall -Werror -D_FORTIFY_SOURCE=2 -fstack-protector-strong
 
 jobs:
   clang12:
     runs-on: ubuntu-20.04
     env:
-      CFLAGS: -O2 -Wformat -Wformat-security -Wall -Werror -Wno-overloaded-virtual -D_FORTIFY_SOURCE=2 -fstack-protector-strong
       CC: /usr/bin/clang-12
       CXX: /usr/bin/clang++-12
       ASM: /usr/bin/clang-12
@@ -72,7 +71,6 @@ jobs:
   gcc10:
     runs-on: ubuntu-20.04
     env:
-      CFLAGS: -O2 -Wformat -Wformat-security -Wall -Werror -D_FORTIFY_SOURCE=2 -fstack-protector-strong
       CC: /usr/bin/gcc-10
       CXX: /usr/bin/g++-10
       ASM: /usr/bin/gcc-10


### PR DESCRIPTION
Fix: oneapi-src/oneVPL-intel-gpu#6

After the following fix in the core we can revert wa for clang-12:
* d1ab5c2 ("Core: partial clean up of OPAQ functions in CORE")

This reverts commit ee52257b18bb345408f610313bf41bd0a3cebae4.