### PR TITLE
[Jpegd] Fix the number of scan access out of bounds issue

### DIFF
--- a/_studio/shared/umc/codec/jpeg_dec/src/mfx_mjpeg_task.cpp
+++ b/_studio/shared/umc/codec/jpeg_dec/src/mfx_mjpeg_task.cpp
@@ -249,6 +249,10 @@ mfxStatus CJpegTask::AddPicture(UMC::MediaDataEx *pSrcData,
             m_pics[m_numPic]->scanOffset[numScans] = pAuxData->offsets[i];
             m_pics[m_numPic]->scanSize[numScans] = chunkSize;
             numScans += 1;
+            if (numScans >= maxNumScans)
+            {
+                throw UMC::UMC_ERR_INVALID_STREAM;
+            }
         }
         else if ((JM_DRI == marker || JM_DQT == marker || JM_DHT == marker) && 0 != numScans)
         {


### PR DESCRIPTION
when numScans > 3 in error clip, the program will get an out of bounds
read error.

Test: manually