### PR TITLE
build: fix build with -Wl,--as-needed

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -4,6 +4,7 @@ on: [ push, pull_request ]
 
 env:
   CFLAGS: -O2 -Wformat -Wformat-security -Wall -Werror -D_FORTIFY_SOURCE=2 -fstack-protector-strong
+  LDFLAGS: -Wl,--as-needed
 
 jobs:
   clang12:

--- a/_studio/shared/umc/core/vm/CMakeLists.txt
+++ b/_studio/shared/umc/core/vm/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(vm
     ipp
   PRIVATE
     mfx_sdl_properties
+    ${CMAKE_DL_LIBS}
   )
 
 include(sources_ext.cmake OPTIONAL)

--- a/builder/FindInternals.cmake
+++ b/builder/FindInternals.cmake
@@ -96,7 +96,7 @@ target_link_options(mfx_shared_lib
       /PDB:$<TARGET_PDB_FILE_DIR:$<TARGET_PROPERTY:NAME>>/$<TARGET_PROPERTY:NAME>_full.pdb
       /PDBSTRIPPED:$<TARGET_PDB_FILE_DIR:$<TARGET_PROPERTY:NAME>>/$<TARGET_PROPERTY:NAME>.pdb
     >
-    $<$<PLATFORM_ID:Linux>:LINKER:--no-undefined,-z,relro,-z,now,-z,noexecstack,--no-as-needed>
+    $<$<PLATFORM_ID:Linux>:LINKER:--no-undefined,-z,relro,-z,now,-z,noexecstack>
   )
 
 target_link_libraries(mfx_shared_lib
@@ -154,7 +154,7 @@ add_library(mfx_va_properties INTERFACE) # va stands for video acceleration
 
 target_link_options(mfx_va_properties
   INTERFACE
-    $<$<PLATFORM_ID:Linux>:LINKER:--no-undefined,-z,relro,-z,now,-z,noexecstack,--no-as-needed>
+    $<$<PLATFORM_ID:Linux>:LINKER:--no-undefined,-z,relro,-z,now,-z,noexecstack>
   )
 
 target_link_libraries(mfx_va_properties


### PR DESCRIPTION
Fixes: oneapi-src/oneVPL-intel-gpu#111

-Wl,--no-as-needed is actually a GNU Linker default (see man 1 ld), we
don't need to explicitly specify it on a linker cmdline. Especially
considering that some Linux distros on purpose build with the
-Wl,--as-needed instead.

-Wl,--as-needed looks to be stronger requirement than -Wl,--no-as-needed,
so it seems reasonable to use this as a default for our CI.

Finally, below build issue which we encounter with -Wl,--as-needed is
caused by missing -ldl for the internal library where we
actually use dlopen() stuff. We did have -ldl on a cmdline, but it was
at a wrong location, i.e. was added by cmake earlier than actually needed,
which caused link error.

[100%] Linking CXX shared library ../../__bin/None/libmfx-gen.so
/usr/bin/ld: ../../__lib/None/libvm.a(vm_shared_object_linux32.c.o): in function `vm_so_load':
vm_shared_object_linux32.c:(.text+0xc): undefined reference to `dlopen'

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>