### PR TITLE
build: fix build failure due to missing AEncUpdateFrame

### DIFF
--- a/_studio/enctools/src/mfx_enctools_aenc.cpp
+++ b/_studio/enctools/src/mfx_enctools_aenc.cpp
@@ -28,7 +28,7 @@
 
 mfxStatus AEncInit(mfxHDL*, AEncParam) { return MFX_ERR_UNSUPPORTED; }
 mfxStatus AEncProcessFrame(mfxHDL, mfxU32, mfxU8*, mfxI32, AEncFrame*) { return MFX_ERR_UNSUPPORTED; }
-void AEncUpdateFrame(mfxHDL, mfxU32, mfxU32, mfxU32, mfxU32) {}
+void AEncUpdateFrame(mfxHDL, mfxU32, mfxU32, mfxU32) {}
 void AEncClose(mfxHDL) {}
 mfxU16 AEncGetIntraDecision(mfxHDL, mfxU32) { return 0; }
 mfxU16 AEncGetPersistenceMap(mfxHDL, mfxU32, mfxU8[]) { return 0; }


### PR DESCRIPTION
mfx_enctools_aenc.cpp:(.text+0x51e): undefined reference to `AEncUpdateFrame'

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>