### PR TITLE
hevce: use Low Power mode for RGB encoding by default

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy_defaults.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_legacy_defaults.cpp
@@ -1386,7 +1386,8 @@ public:
             return par.mfx.LowPower;
 
         auto fcc = par.mfx.FrameInfo.FourCC;
-        bool bOn = fcc == MFX_FOURCC_AYUV || fcc == MFX_FOURCC_Y410 || fcc == MFX_FOURCC_A2RGB10;
+        bool bOn = fcc == MFX_FOURCC_AYUV || fcc == MFX_FOURCC_Y410 ||
+                   fcc == MFX_FOURCC_A2RGB10 || fcc == MFX_FOURCC_RGB4;
 
         return mfxU16(
             bOn * MFX_CODINGOPTION_ON


### PR DESCRIPTION
According to: https://github.com/intel/media-driver/blob/master/docs/media_features.md. Only VDENC supports RGB encoding, so use lowpower when input RGB data.