### PR TITLE
[VPP] correct the settings for detail filter

### DIFF
--- a/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
+++ b/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
@@ -6329,16 +6329,16 @@ mfxStatus ConfigureExecuteParams(
                 if(caps.uDetailFilter)
                 {
                     executeParams.bDetailAutoAdjust = TRUE;
+                    executeParams.detailFactor = 32;// default
                     for (mfxU32 i = 0; i < videoParam.NumExtParam; i++)
                     {
-                        executeParams.detailFactor = 32;// default
                         if (videoParam.ExtParam[i]->BufferId == MFX_EXTBUFF_VPP_DETAIL)
                         {
                             mfxExtVPPDetail *extDetail = (mfxExtVPPDetail*) videoParam.ExtParam[i];
                             executeParams.detailFactor = MapDNFactor(extDetail->DetailFactor);
                             executeParams.detailFactorOriginal = extDetail->DetailFactor;
+                            executeParams.bDetailAutoAdjust = FALSE;
                         }
-                        executeParams.bDetailAutoAdjust = FALSE;
                     }
                 }
                 else


### PR DESCRIPTION
Without this fix, the factor for detail filter is always 32 when the last buffer in the mfxExtBuffer list is not MFX_EXTBUFF_VPP_DETAIL.

Moreover if user doesn't provide MFX_EXTBUFF_VPP_DETAIL buffer, executeParams.bDetailAutoAdjust should be true.

Signed-off-by: Haihao Xiang <haihao.xiang@intel.com>