### PR TITLE
[HEVCe] Add general_max_14bit_constraint_flag in SPS for SCC profile

### DIFF
--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_data.h
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_data.h
@@ -114,7 +114,8 @@ namespace Base
                 mfxU32 intra            : 1;
                 mfxU32 one_picture_only : 1;
                 mfxU32 lower_bit_rate   : 1;
-                mfxU32                  : 23;
+                mfxU32 max_14bit        : 1;
+                mfxU32                  : 22;
             } constraint;
         };
         mfxU32 rext_constraint_flags_32_42  : 11;

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_packer.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_packer.cpp
@@ -498,7 +498,8 @@ void Packer::PackPTL(BitstreamWriter& bs, LayersInfo const & profile_tier_level,
     bs.PutBit(profile_tier_level.general.constraint.intra           );
     bs.PutBit(profile_tier_level.general.constraint.one_picture_only);
     bs.PutBit(profile_tier_level.general.constraint.lower_bit_rate  );
-    bs.PutBits(23, 0);
+    bs.PutBit(profile_tier_level.general.constraint.max_14bit       );
+    bs.PutBits(22, 0);
     bs.PutBits(11, 0);
     bs.PutBit(profile_tier_level.general.inbld_flag);
     bs.PutBits(8, profile_tier_level.general.level_idc);
@@ -536,7 +537,8 @@ void Packer::PackPTL(BitstreamWriter& bs, LayersInfo const & profile_tier_level,
             bs.PutBit(profile_tier_level.general.constraint.intra);
             bs.PutBit(profile_tier_level.general.constraint.one_picture_only);
             bs.PutBit(profile_tier_level.general.constraint.lower_bit_rate);
-            bs.PutBits(23, 0);
+            bs.PutBit(profile_tier_level.general.constraint.max_14bit);
+            bs.PutBits(22, 0);
             bs.PutBits(11, 0);
             bs.PutBit(sl.inbld_flag);
         }

--- a/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_scc.cpp
+++ b/_studio/mfx_lib/encode_hw/hevc/agnostic/base/hevcehw_base_scc.cpp
@@ -160,6 +160,7 @@ void SCC::Query1NoCaps(const FeatureBlocks& /*blocks*/, TPushQ1 Push)
             vps.general.constraint.max_422chroma = (defpar.mvp.mfx.FrameInfo.ChromaFormat != MFX_CHROMAFORMAT_YUV444);
             vps.general.constraint.max_420chroma = (defpar.mvp.mfx.FrameInfo.ChromaFormat != MFX_CHROMAFORMAT_YUV444);
             vps.general.constraint.lower_bit_rate = 1;
+            vps.general.constraint.max_14bit = 1;
 
             return sts;
         });


### PR DESCRIPTION
Follow spec(11/2019) table A.5.