### PR TITLE
vpp: avoid double free

### DIFF
--- a/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
+++ b/_studio/mfx_lib/vpp/src/mfx_vpp_hw.cpp
@@ -7185,6 +7185,7 @@ mfxStatus MfxFrameAllocResponse::Free( void )
         {
             NumFrameActual = m_numFrameActualReturnedByAllocFrames;
             m_core->FreeFrames(this);
+            mids = NULL;
         }
     }
 


### PR DESCRIPTION
Free() might be called multiple times, we should avoid double free in Free().