### PR TITLE
Fix trailing newline in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,3 +144,4 @@ message("  BUILD_KERNELS                           : ${BUILD_KERNELS}")
 message("*****************************************************************************")
 
 include(sources_ext.cmake OPTIONAL)
+


### PR DESCRIPTION
## Summary
This change restores the trailing newline at the end of `CMakeLists.txt` so the file stays in the repository's expected formatting state.

## Why
The project file had a missing final newline, which creates noisy editor diffs without changing the build logic. Keeping the file normalized avoids unnecessary churn during future edits.

## Testing
- Verified the repo contains the single intended change in `CMakeLists.txt`.